### PR TITLE
Fix culture-specific formatting in GetRings serialization

### DIFF
--- a/src/LibEsri/Layer.cs
+++ b/src/LibEsri/Layer.cs
@@ -81,7 +81,7 @@ public class Layer
 			string[] points = new string[poly.Edges.Count + 1];
 
 			for (int j = 0; j < poly.Edges.Count; j++)
-				points[j] = $"%5B{poly.Edges[j].Origin.X},{poly.Edges[j].Origin.Y}%5D";
+				points[j] = FormattableString.Invariant($"%5B{poly.Edges[j].Origin.X},{poly.Edges[j].Origin.Y}%5D");
 			points[^1] = points[0];
 
 			rings[i] = "%5B" + string.Join("%2C", points) + "%5D";


### PR DESCRIPTION
This PR updates the `GetRings` method to use` FormattableString.Invariant` for coordinate serialization.

Previously, the code relied on standard string interpolation` ($"")`, which uses the current thread's culture. On systems where the decimal separator is a comma (e.g., European locales), this resulted in invalid coordinate strings (e.g., `12,34` instead of `12.34`), breaking the output format. So this happened in my case. And availability was always empty.

So, this change ensures coordinates are always serialized with a dot separator regardless of the server's locale.
